### PR TITLE
Turn module on for all environments

### DIFF
--- a/load.php
+++ b/load.php
@@ -11,7 +11,7 @@ use HM\Platform\XRay;
 require_once __DIR__ . '/inc/namespace.php';
 
 add_action( 'hm-platform.modules.init', function () {
-	$is_cloud = in_array( get_environment_architecture(), [ 'ec2', 'ecs' ] );
+	$is_cloud = in_array( get_environment_architecture(), [ 'ec2', 'ecs' ], true );
 	$default_settings = [
 		'enabled'            => true,
 		'cavalcade'          => true,

--- a/load.php
+++ b/load.php
@@ -11,16 +11,17 @@ use HM\Platform\XRay;
 require_once __DIR__ . '/inc/namespace.php';
 
 add_action( 'hm-platform.modules.init', function () {
+	$is_cloud = in_array( get_environment_architecture(), [ 'ec2', 'ecs' ] );
 	$default_settings = [
-		'enabled'            => in_array( get_environment_architecture(), [ 'ec2', 'ecs', 'local-server' ] ),
+		'enabled'            => true,
 		'cavalcade'          => true,
 		's3-uploads'         => true,
-		'aws-ses-wp-mail'    => true,
-		'batcache'           => true,
+		'aws-ses-wp-mail'    => $is_cloud,
+		'batcache'           => $is_cloud,
 		'redis'              => true,
 		'ludicrousdb'        => true,
 		'healthcheck'        => true,
-		'xray'               => true,
+		'xray'               => $is_cloud,
 		'email-from-address' => 'no-reply@humanmade.com',
 	];
 


### PR DESCRIPTION
This changes the configuration to be more granular, and only turns off the non-production parts of the configuration. This ensures things like Redis work locally.