### PR TITLE
Allow overriding Accept with `_accept=json`

### DIFF
--- a/plugins/healthcheck/inc/namespace.php
+++ b/plugins/healthcheck/inc/namespace.php
@@ -31,7 +31,15 @@ function output_page( array $checks ) {
 	}
 	nocache_headers();
 
+	$format = 'html';
 	if ( ! empty( $_SERVER['HTTP_ACCEPT'] ) && $_SERVER['HTTP_ACCEPT'] === 'application/json' ) {
+		$format = 'json';
+	}
+	if ( $_GET['_accept'] ?? '' === 'json' ) {
+		$format = 'json';
+	}
+
+	if ( $format === 'json' ) {
 		echo json_encode( $checks );
 		exit;
 	}


### PR DESCRIPTION
Currently we don't pass the `Accept` header to the origin via the CDN, for cache performance reasons. This is unlikely to change soon, so I added support for specifying it via a query param.