### PR TITLE
Audit Log to CloudWatch

### DIFF
--- a/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
+++ b/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
@@ -89,7 +89,8 @@ class CloudWatch_Driver implements DB_Driver_Interface {
 		}
 
 		if ( $args['date_to'] ) {
-			$field_where[] = sprintf( 'created_timestamp < %d ', strtotime( $args['date_to'] ) * 1000 );
+			// Because date_to is in the format 2019/04/17, we want to really say the create date is less then 2019/04/17 23:59:59
+			$field_where[] = sprintf( 'created_timestamp < %d ', ( strtotime( $args['date_to'] ) + DAY_IN_SECONDS ) * 1000 );
 		}
 
 		if ( $args['date_from'] ) {

--- a/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
+++ b/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace HM\Platform\Cloud\Audit_Log_To_CloudWatch;
+
+use Aws\CloudWatch\CloudWatchClient;
+use function HM\Platform\Cloud\CloudWatch_Logs\cloudwatch_logs_client;
+use function HM\Platform\Cloud\CloudWatch_Logs\send_events_to_stream;
+use function HM\Platform\get_environment_name;
+use function HM\Platform\get_aws_sdk;
+use WP_Stream\DB_Driver as DB_Driver_Interface;
+
+class CloudWatch_Driver implements DB_Driver_Interface {
+	/**
+	 * Holds Query class
+	 *
+	 * @var Query
+	 */
+	protected $query;
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		wp_cache_add_global_groups( 'stream_column_values' );
+	}
+
+	/**
+	 * Insert a record.
+	 *
+	 * @param array $data Data to insert.
+	 *
+	 * @return int
+	 */
+	public function insert_record( $data ) {
+		if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
+			return false;
+		}
+
+		$result = send_events_to_stream( [ [ 'timestamp' => time() * 1000, 'message' => json_encode( $data ) ] ], get_environment_name() . '/audit-log', 'items' );
+
+		// Add the values to the column values caches if they exist
+		foreach ( $data as $column => $value ) {
+			$cache = wp_cache_get( $column, 'stream_column_values' );
+			if ( $cache === false || in_array( $value, $cache, true ) ) {
+				continue;
+			}
+			$cache[] = $value;
+			wp_cache_set( $column, $cache, 'stream_column_values' );
+		}
+	}
+
+	/**
+	 * Retrieve records
+	 *
+	 * @param array $args
+	 *
+	 * @return array
+	 */
+		/**
+	 * Retrieve records
+	 *
+	 * @param array $args
+	 *
+	 * @return array
+	 */
+	public function get_records( $args ) {
+		$fields = [
+			'blog_id',
+			'site_id',
+			'user_id',
+			'user_role',
+			'connector',
+			'context',
+			'action',
+			'ip',
+			'object_id',
+		];
+
+		$field_where = [];
+		foreach ( $fields as $field ) {
+			if ( $args[ $field ] || $args[ $field ] === '0' ) {
+				$field_where[] = sprintf( '%s = "%s" ', $field, $args[ $field ] );
+			}
+		}
+
+		if ( $args['search'] ) {
+			$field_where[] = sprintf( '%s like "%s" ', $args['search_field'], $args['search'] );
+		}
+
+		if ( $field_where ) {
+			$where = sprintf( '| filter ( %s )', implode( ' and ', $field_where ) );
+		}
+
+		$limit = $args['records_per_page'] + ( absint( $args['paged'] - 1 ) * $args['records_per_page'] );
+		$offset = absint( $args['paged'] - 1 ) * $args['records_per_page'];
+		$order = $args['order'];
+
+		$query = "fields @message $where | sort @timestamp $order";
+
+		$params = [
+			'logGroupName'   => get_environment_name() . '/audit-log',
+			'limit'          => $limit,
+			'endTime'        => time() * 1000,
+			'startTime'      => 0,
+			'queryString'    => $query,
+		];
+
+		$query = cloudwatch_logs_client()->startQuery( $params );
+
+		$results = [ 'status' => 'Running' ];
+		while ( ! in_array( $results['status'], [ 'Failed', 'Cancelled', 'Complete' ], true ) ) {
+			$results = cloudwatch_logs_client()->getQueryResults([
+				'queryId' => $query['queryId'],
+			] );
+		}
+
+		/**
+		 * Future optimization: currently we have to pull all results up until the offset.
+		 * There's no way in the CloudWatch Insights API to supply a number offset.
+		 */
+		$items = [];
+		$count = 0;
+		foreach ( $results['results'] as $result ) {
+			$count++;
+			if ( $count < $offset ) {
+				continue;
+			}
+			$object = json_decode( $result[0]['value'] );
+			$object->meta = json_decode( json_encode( $object->meta ), true );
+			$items[] = $object;
+		}
+
+		return [
+			'items' => $items,
+			'count' => $results['statistics']['recordsMatched'],
+		];
+	}
+
+
+	/**
+	 * Returns array of existing values for requested column.
+	 * Used to fill search filters with only used items, instead of all items.
+	 *
+	 * @param string $column
+	 *
+	 * @return array
+	 */
+	public function get_column_values( $column ) {
+		$values = wp_cache_get( $column, 'stream_column_values' );
+		if ( $values === false ) {
+			$query = "stats distinct( $column ) by $column";
+
+			$params = [
+				'logGroupName'   => get_environment_name() . '/audit-log',
+				'endTime'        => time() * 1000,
+				'startTime'      => 0,
+				'queryString'    => $query,
+			];
+
+			$query = cloudwatch_logs_client()->startQuery( $params );
+			$results = [ 'status' => 'Running' ];
+			while ( ! in_array( $results['status'], [ 'Failed', 'Cancelled', 'Complete' ], true ) ) {
+				$results = cloudwatch_logs_client()->getQueryResults([
+					'queryId' => $query['queryId'],
+				] );
+			}
+
+			foreach ( $results['results'] as $result ) {
+				$values[] = $result[0]['value'];
+			}
+
+			wp_cache_set( $column, $values, 'stream_column_values' );
+		}
+
+		$values = array_map( function ( $value ) : array {
+			return [ 'cell' => $value ];
+		}, $values );
+
+		return $values;
+	}
+
+	/**
+	 * Public getter to return table names
+	 *
+	 * @return array
+	 */
+	public function get_table_names() {
+		return [];
+	}
+
+	/**
+	 * Init storage.
+	 *
+	 * @param \WP_Stream\Plugin $plugin Instance of the plugin.
+	 * @return \WP_Stream\Install
+	 */
+	public function setup_storage( $plugin ) {
+		//
+	}
+
+	/**
+	 * Purge storage.
+	 *
+	 * @param \WP_Stream\Plugin $plugin Instance of the plugin.
+	 * @return \WP_Stream\Uninstall
+	 */
+	public function purge_storage( $plugin ) {
+		// no op.
+		return;
+	}
+
+	protected function get_cloudwatch_client() : CloudWatchClient {
+		$client = get_aws_sdk()->createCloudWatch();
+		return $client;
+	}
+}

--- a/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
+++ b/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
@@ -56,13 +56,6 @@ class CloudWatch_Driver implements DB_Driver_Interface {
 	 *
 	 * @return array
 	 */
-		/**
-	 * Retrieve records
-	 *
-	 * @param array $args
-	 *
-	 * @return array
-	 */
 	public function get_records( $args ) {
 		$fields = [
 			'blog_id',

--- a/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
+++ b/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
@@ -190,17 +190,18 @@ class CloudWatch_Driver implements DB_Driver_Interface {
 	 * Init storage.
 	 *
 	 * @param \WP_Stream\Plugin $plugin Instance of the plugin.
-	 * @return \WP_Stream\Install
+	 * @return null
 	 */
 	public function setup_storage( $plugin ) {
-		//
+		// no op.
+		return;
 	}
 
 	/**
 	 * Purge storage.
 	 *
 	 * @param \WP_Stream\Plugin $plugin Instance of the plugin.
-	 * @return \WP_Stream\Uninstall
+	 * @return null
 	 */
 	public function purge_storage( $plugin ) {
 		// no op.

--- a/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
+++ b/inc/audit_log_to_cloudwatch/class-cloudwatch-driver.php
@@ -79,12 +79,12 @@ class CloudWatch_Driver implements DB_Driver_Interface {
 		$field_where = [];
 		foreach ( $fields as $field ) {
 			if ( $args[ $field ] || $args[ $field ] === '0' ) {
-				$field_where[] = sprintf( '%s = "%s" ', $field, $args[ $field ] );
+				$field_where[] = sprintf( '%s = "%s" ', $field, esc_sql( $args[ $field ] ) );
 			}
 		}
 
 		if ( $args['search'] ) {
-			$field_where[] = sprintf( '%s like "%s" ', $args['search_field'], $args['search'] );
+			$field_where[] = sprintf( '%s like "%s" ', $args['search_field'], esc_sql( $args['search'] ) );
 		}
 
 		if ( $field_where ) {

--- a/inc/audit_log_to_cloudwatch/namespace.php
+++ b/inc/audit_log_to_cloudwatch/namespace.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace HM\Platform\Cloud\Audit_Log_To_CloudWatch;
+
+use function HM\Platform\get_environment_architecture;
+
+/**
+ * Bootstrap the audit log to cloudwatch integration.
+ */
+function bootstrap() {
+	add_filter( 'wp_stream_db_driver', __NAMESPACE__ . '\\set_stream_db_driver' );
+}
+
+/**
+ * Set the Stream DB Driver to the CloudWatch integration.
+ *
+ * This is only done when we we are deemed to have a connection to CloudWatch available.
+ *
+ * @param string $db_driver
+ * @return string
+ */
+function set_stream_db_driver( string $db_driver ) : string {
+	require_once __DIR__ . '/class-cloudwatch-driver.php';
+	return __NAMESPACE__ . '\\CloudWatch_Driver';
+}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -20,6 +20,8 @@ function boostrap_cavalcade_runner() {
  * that was passed in at the end of the function.
  */
 function bootstrap( $wp_debug_enabled ) {
+	$config = get_config();
+
 	if ( ! defined( 'WP_CACHE' ) ) {
 		define( 'WP_CACHE', true );
 	}
@@ -70,6 +72,12 @@ function bootstrap( $wp_debug_enabled ) {
 		require_once __DIR__ . '/cloudwatch_error_handler/namespace.php';
 		CloudWatch_Error_Handler\bootstrap();
 	}
+
+	if ( $config['audit-log-to-cloudwatch'] ) {
+		require_once __DIR__ . '/audit_log_to_cloudwatch/namespace.php';
+		Audit_Log_To_CloudWatch\bootstrap();
+	}
+
 	return $wp_debug_enabled;
 }
 

--- a/load.php
+++ b/load.php
@@ -13,16 +13,17 @@ require_once __DIR__ . '/inc/namespace.php';
 add_action( 'hm-platform.modules.init', function () {
 	$is_cloud = in_array( get_environment_architecture(), [ 'ec2', 'ecs' ], true );
 	$default_settings = [
-		'enabled'            => true,
-		'cavalcade'          => true,
-		's3-uploads'         => true,
-		'aws-ses-wp-mail'    => $is_cloud,
-		'batcache'           => $is_cloud,
-		'redis'              => true,
-		'ludicrousdb'        => true,
-		'healthcheck'        => true,
-		'xray'               => $is_cloud,
-		'email-from-address' => 'no-reply@humanmade.com',
+		'enabled'                 => true,
+		'cavalcade'               => true,
+		's3-uploads'              => true,
+		'aws-ses-wp-mail'         => $is_cloud,
+		'batcache'                => $is_cloud,
+		'redis'                   => true,
+		'ludicrousdb'             => true,
+		'healthcheck'             => true,
+		'xray'                    => $is_cloud,
+		'email-from-address'      => 'no-reply@humanmade.com',
+		'audit-log-to-cloudwatch' => $is_cloud,
 	];
 
 	register_module( 'cloud', __DIR__, 'Cloud', $default_settings, function () {


### PR DESCRIPTION
Initially this was part of the security module, but I think it actually makes a lot more sense here. This switches out the Stream DB provider for AWS CLoudWatch Logs in the cloud environments.