### PR TITLE
Add check for add_action

### DIFF
--- a/load.php
+++ b/load.php
@@ -15,7 +15,6 @@ if ( ! function_exists( 'add_action' ) ) {
 	return;
 }
 
-
 add_action( 'hm-platform.modules.init', function () {
 	$is_cloud = in_array( get_environment_architecture(), [ 'ec2', 'ecs' ], true );
 	$default_settings = [

--- a/load.php
+++ b/load.php
@@ -10,6 +10,12 @@ use HM\Platform\XRay;
 
 require_once __DIR__ . '/inc/namespace.php';
 
+// Don't self-initialize if this is not a Platform execution.
+if ( ! function_exists( 'add_action' ) ) {
+	return;
+}
+
+
 add_action( 'hm-platform.modules.init', function () {
 	$is_cloud = in_array( get_environment_architecture(), [ 'ec2', 'ecs' ], true );
 	$default_settings = [

--- a/wp-config.php
+++ b/wp-config.php
@@ -7,6 +7,11 @@
 
 use const HM\Platform\ROOT_DIR;
 
+// Don't self-initialize if this is not a Platform execution.
+if ( ! function_exists( 'add_action' ) ) {
+	return;
+}
+
 if ( file_exists( ROOT_DIR . '/wp-config-production.php' ) ) {
 	require_once ROOT_DIR . '/wp-config-production.php';
 }


### PR DESCRIPTION
Per https://github.com/humanmade/platform-dev/issues/323, we are screwing up any inclusion of autoload.php outside of the wp-config.php. We're discussing a better long term solution in https://github.com/humanmade/platform-dev/pull/325, but this is intended to get things functioning.