### PR TITLE
Support EC2 infra.

### DIFF
--- a/load.php
+++ b/load.php
@@ -18,17 +18,19 @@ if ( ! function_exists( 'add_action' ) ) {
 add_action( 'hm-platform.modules.init', function () {
 	$is_cloud = in_array( get_environment_architecture(), [ 'ec2', 'ecs' ], true );
 	$default_settings = [
-		'enabled'                 => true,
-		'cavalcade'               => true,
-		's3-uploads'              => true,
-		'aws-ses-wp-mail'         => $is_cloud,
-		'batcache'                => $is_cloud,
-		'redis'                   => true,
-		'ludicrousdb'             => true,
-		'healthcheck'             => true,
-		'xray'                    => $is_cloud,
-		'email-from-address'      => 'no-reply@humanmade.com',
-		'audit-log-to-cloudwatch' => $is_cloud,
+		'enabled'                  => true,
+		'cavalcade'                => true,
+		's3-uploads'               => true,
+		'aws-ses-wp-mail'          => $is_cloud,
+		'batcache'                 => $is_cloud,
+		'redis'                    => true,
+		'memcached'                => get_environment_architecture() === 'ec2',
+		'ludicrousdb'              => true,
+		'healthcheck'              => true,
+		'xray'                     => $is_cloud,
+		'email-from-address'       => 'no-reply@humanmade.com',
+		'audit-log-to-cloudwatch'  => $is_cloud,
+		'php-errors-to-cloudwatch' => $is_cloud,
 	];
 
 	register_module( 'cloud', __DIR__, 'Cloud', $default_settings, function () {


### PR DESCRIPTION
Currenly we only support the ECS infrastructure, but I think given it's not much to add, we should also support the EC2 infra. Without that, we are goign to need to wait to migrate all clients to ECS before they can use Altis, which I think is going to be a hold-up for many trying it out.