### PR TITLE
Fix batcache via define

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -23,10 +23,6 @@ function boostrap_cavalcade_runner() {
 function bootstrap( $wp_debug_enabled ) {
 	$config = get_config();
 
-	if ( ! defined( 'WP_CACHE' ) ) {
-		define( 'WP_CACHE', true );
-	}
-
 	/**
 	 * In Cloud, the User Agent is not available via the headers, as it is stripped at the CDN level. This is to
 	 * preserve cache-key generation, as it's not possible to get access to headers that will cause a highly

--- a/load.php
+++ b/load.php
@@ -47,6 +47,10 @@ add_action( 'hm-platform.modules.init', function () {
 			XRay\bootstrap();
 		}
 
+		if ( $config['batcache'] && ! defined( 'WP_CACHE' ) ) {
+			define( 'WP_CACHE', true );
+		}
+
 		add_filter( 'wp_mail_from', function ( string $email ) use ( $config ) : string {
 			return $config['email-from-address'];
 		}, 1 );


### PR DESCRIPTION
Currently we define `WP_CACHE` on `enable_wp_debug_mode_checks`, which is too late -- defualt constants are already loaded setting WP_CACHE to `false`.